### PR TITLE
Add option to constructor of \yrmcds\Client for detecting stale connection

### DIFF
--- a/yrmcds-api.php
+++ b/yrmcds-api.php
@@ -316,9 +316,13 @@ class Client {
      * @param int     $port        The port number.
      * @param string  $persist_id  Persistent connection ID.
      * @param string  $prefix      Auto-prefix for keys.
+     * @param bool    $detect_stale_connection
+     *                             If true, checks for stale persistent connection and
+     *                             automatically reconnect when the connection is broken.
      */
     function __construct($node, $port = 11211,
-                         $persist_id = NULL, $prefix = NULL) {}
+                         $persist_id = NULL, $prefix = NULL,
+                         $detect_stale_connection = FALSE) {}
 
     /**
      * Set socket timeouts.

--- a/yrmcds.c
+++ b/yrmcds.c
@@ -81,6 +81,15 @@ static zend_class_entry* ce_yrmcds_client;
 static zend_class_entry* ce_yrmcds_error;
 static zend_class_entry* ce_yrmcds_response;
 
+static void on_broken_connection_detected(const php_yrmcds_t* conn, int err) {
+    PRINT_YRMCDS_ERROR(err);
+    php_log_err("yrmcds: broken persistent connection" TSRMLS_CC);
+    char* hash_key;
+    int hash_key_len = HASH_KEY(hash_key, conn->persist_id);
+    zend_hash_del(&EG(persistent_list), hash_key, hash_key_len + 1);
+    efree(hash_key);
+}
+
 /* Resource destructors. */
 static void php_yrmcds_resource_dtor(zend_rsrc_list_entry* rsrc TSRMLS_DC) {
     php_yrmcds_t* c = (php_yrmcds_t*)rsrc->ptr;
@@ -101,12 +110,7 @@ static void php_yrmcds_resource_dtor(zend_rsrc_list_entry* rsrc TSRMLS_DC) {
         }
 
       ERROR:
-        PRINT_YRMCDS_ERROR(e);
-        php_log_err("yrmcds: broken persistent connection" TSRMLS_CC);
-        char* hash_key;
-        int hash_key_len = HASH_KEY(hash_key, c->persist_id);
-        zend_hash_del(&EG(persistent_list), hash_key, hash_key_len + 1);
-        efree(hash_key);
+        on_broken_connection_detected(c, e);
         return;
     }
     yrmcds_close(&c->res);
@@ -123,12 +127,49 @@ static void php_yrmcds_resource_pdtor(zend_rsrc_list_entry* rsrc TSRMLS_DC) {
     pefree(c, 1);
 }
 
+static int check_persistent_connection(php_yrmcds_t* conn) {
+    uint32_t serial;
+    int e = yrmcds_noop(&conn->res, &serial);
+    if( e != 0 ) return e;
+    while( 1 ) {
+        yrmcds_response r;
+        e = yrmcds_recv(&conn->res, &r);
+        if( e != YRMCDS_STATUS_OK )
+            return e;
+        if( r.serial == serial )
+            return 0;
+    }
+}
+
+static int use_existing_persistent_connection(
+        const char* hash_key, int hash_key_len,
+        zend_bool detect_stale_connection, int* res) {
+    zend_rsrc_list_entry* existing_conn;
+
+    if( zend_hash_find(&EG(persistent_list), hash_key, hash_key_len+1,
+                (void**)&existing_conn) != SUCCESS )
+        return -1;
+
+    php_yrmcds_t* c = existing_conn->ptr;
+    if( detect_stale_connection ) {
+        int e = check_persistent_connection(c);
+        if (e != 0) {
+            on_broken_connection_detected(c, e);
+            return -1;
+        }
+    }
+
+    *res = zend_list_insert(existing_conn->ptr, le_yrmcds TSRMLS_CC);
+    return 0;
+}
+
 // \yrmcds\Client::__construct
 ZEND_BEGIN_ARG_INFO_EX(AI(Client, __construct), 0, ZEND_RETURN_VALUE, 1)
     ZEND_ARG_INFO(0, "node")
     ZEND_ARG_INFO(0, "port")
     ZEND_ARG_INFO(0, "persistent_id")
     ZEND_ARG_INFO(0, "prefix")
+    ZEND_ARG_INFO(0, "detect_stale_connection")
 ZEND_END_ARG_INFO()
 
 YRMCDS_METHOD(Client, __construct) {
@@ -139,6 +180,7 @@ YRMCDS_METHOD(Client, __construct) {
     int persist_id_len = 0;
     char* prefix = NULL;
     int prefix_len = 0;
+    zend_bool detect_stale_connection = 0;
 
     zval* objptr = getThis();
     if( ! objptr ) {
@@ -146,10 +188,11 @@ YRMCDS_METHOD(Client, __construct) {
         RETURN_FALSE;
     }
 
-    if( zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "s|ls!s!",
+    if( zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "s|ls!s!b",
                               &node, &node_len, &port,
                               &persist_id, &persist_id_len,
-                              &prefix, &prefix_len) == FAILURE ) {
+                              &prefix, &prefix_len,
+                              &detect_stale_connection) == FAILURE ) {
         php_error(E_ERROR, "Invalid argument");
         RETURN_FALSE;
     }
@@ -158,13 +201,10 @@ YRMCDS_METHOD(Client, __construct) {
     if( persist_id_len > 0 ) {
         char* hash_key;
         int hash_key_len = HASH_KEY(hash_key, persist_id);
-        zend_rsrc_list_entry* existing_conn;
 
-        if( zend_hash_find(&EG(persistent_list), hash_key, hash_key_len+1,
-                           (void**)&existing_conn) == SUCCESS ) {
-            res = zend_list_insert(existing_conn->ptr, le_yrmcds TSRMLS_CC);
-
-        } else {
+        int e = use_existing_persistent_connection(
+                    hash_key, hash_key_len, detect_stale_connection, &res);
+        if (e != 0) {
             php_yrmcds_t* c = pemalloc(sizeof(php_yrmcds_t), 1);
             c->persist_id = pestrndup(persist_id, persist_id_len, 1);;
             CHECK_YRMCDS( yrmcds_connect(&c->res, node, (uint16_t)port) );


### PR DESCRIPTION
In order to detect stale persistent connections, a new argument `detect_stale_connection` is added to the constructor of `\yrmcds\Client`. When `detect_stale_connection` is true, the constructor sends "noop" command through an existing persistent connection. If the response is correctly received, we can use the persistent connection. Otherwise, we discard the (broken) connection and establish a new persistent connection.

As the side effect, the constructor discards all unreceived responses and the results of all "quiet" commands.
