### PR TITLE
Add option for detecting stale connections

### DIFF
--- a/php_yrmcds.h
+++ b/php_yrmcds.h
@@ -36,6 +36,7 @@ typedef struct {
 ZEND_BEGIN_MODULE_GLOBALS(yrmcds)
     long compression_threshold;
     long default_timeout;
+    zend_bool detect_stale_connection;
 ZEND_END_MODULE_GLOBALS(yrmcds)
 
 #ifdef ZTS

--- a/yrmcds.ini
+++ b/yrmcds.ini
@@ -10,3 +10,9 @@ yrmcds.compression_threshold = 16384
 ;
 ; Default is 5 seconds.
 yrmcds.default_timeout = 5
+
+; If detect_stale_connection is a nonzero value, the constructor of \yrmcds\Client
+; checks for stale persistent connection by emitting "noop" command to a server.
+; If the connection turns out to be stale, the constructor automatically
+; discards the connection and establishes a new persistent connection.
+yrmcds.detect_stale_connection = 1;


### PR DESCRIPTION
In order to detect stale persistent connections, a new option `detect_stale_connection` is added to `yrmcds.ini`. When `detect_stale_connection` is nonzero value, the constructor of `\yrmcds\Client` sends "noop" command through an existing persistent connection. If the response is correctly received, the client use the persistent connection. Otherwise, the client discards the connection and establish a new persistent connection.

As the side effect, the constructor discards all unreceived responses and results of all "quiet" commands.
