### PR TITLE
Check for stale persistent connections

### DIFF
--- a/php_yrmcds.h
+++ b/php_yrmcds.h
@@ -36,6 +36,7 @@ typedef struct {
 ZEND_BEGIN_MODULE_GLOBALS(yrmcds)
     long compression_threshold;
     long default_timeout;
+    zend_bool detect_stale_connection;
 ZEND_END_MODULE_GLOBALS(yrmcds)
 
 #ifdef ZTS

--- a/yrmcds.c
+++ b/yrmcds.c
@@ -81,32 +81,47 @@ static zend_class_entry* ce_yrmcds_client;
 static zend_class_entry* ce_yrmcds_error;
 static zend_class_entry* ce_yrmcds_response;
 
+static void on_broken_connection_detected(
+        php_yrmcds_t* conn, yrmcds_error err, yrmcds_status status TSRMLS_DC) {
+    if( err != YRMCDS_OK )
+        PRINT_YRMCDS_ERROR(err);
+    if( status != YRMCDS_STATUS_OK && status != YRMCDS_STATUS_UNKNOWNCOMMAND ) {
+        char buf[256];
+        snprintf(buf, sizeof(buf), "yrmcds: unexpected response (%d)", status);
+        php_log_err(buf TSRMLS_CC);
+    }
+    php_log_err("yrmcds: broken persistent connection" TSRMLS_CC);
+    char* hash_key;
+    int hash_key_len = HASH_KEY(hash_key, conn->persist_id);
+    zend_hash_del(&EG(persistent_list), hash_key, hash_key_len + 1);
+    efree(hash_key);
+}
+
 /* Resource destructors. */
 static void php_yrmcds_resource_dtor(zend_rsrc_list_entry* rsrc TSRMLS_DC) {
     php_yrmcds_t* c = (php_yrmcds_t*)rsrc->ptr;
     if( c->persist_id ) {
+        yrmcds_status status = YRMCDS_STATUS_OK;
         uint32_t serial;
         yrmcds_set_timeout(&c->res, (int)YRMCDS_G(default_timeout));
         int e = yrmcds_unlockall(&c->res, 0, &serial);
-        if( e != 0 ) goto ERROR;
+        if( e != YRMCDS_OK ) goto ERROR;
         while( 1 ) {
             yrmcds_response r;
             e = yrmcds_recv(&c->res, &r);
-            if( e != YRMCDS_STATUS_OK &&
+            if( e != YRMCDS_OK )
+                goto ERROR;
+            status = r.status;
+            if( status != YRMCDS_STATUS_OK &&
                 // memcached does not support locking, so
-                e != YRMCDS_STATUS_UNKNOWNCOMMAND )
+                status != YRMCDS_STATUS_UNKNOWNCOMMAND )
                 goto ERROR;
             if( r.serial == serial )
                 return;
         }
 
       ERROR:
-        PRINT_YRMCDS_ERROR(e);
-        php_log_err("yrmcds: broken persistent connection" TSRMLS_CC);
-        char* hash_key;
-        int hash_key_len = HASH_KEY(hash_key, c->persist_id);
-        zend_hash_del(&EG(persistent_list), hash_key, hash_key_len + 1);
-        efree(hash_key);
+        on_broken_connection_detected(c, e, status TSRMLS_CC);
         return;
     }
     yrmcds_close(&c->res);
@@ -121,6 +136,53 @@ static void php_yrmcds_resource_pdtor(zend_rsrc_list_entry* rsrc TSRMLS_DC) {
     yrmcds_close(&c->res);
     pefree((void*)c->persist_id, 1);
     pefree(c, 1);
+}
+
+static yrmcds_error check_persistent_connection(
+        php_yrmcds_t* conn, yrmcds_status* status TSRMLS_DC) {
+    yrmcds_error e;
+    *status = YRMCDS_STATUS_OK;
+    e = yrmcds_set_timeout(&conn->res, 1);
+    if( e != YRMCDS_OK ) return e;
+    uint32_t serial;
+    e = yrmcds_noop(&conn->res, &serial);
+    if( e != YRMCDS_OK ) return e;
+    while( 1 ) {
+        yrmcds_response r;
+        e = yrmcds_recv(&conn->res, &r);
+        if( e != YRMCDS_OK )
+            return e;
+        *status = r.status;
+        if( *status != YRMCDS_STATUS_OK )
+            return e;
+        if( r.serial == serial )
+            break;
+    }
+    e = yrmcds_set_timeout(&conn->res, (int)YRMCDS_G(default_timeout));
+    if( e != YRMCDS_OK ) return e;
+    return YRMCDS_OK;
+}
+
+static int use_existing_persistent_connection(
+        const char* hash_key, int hash_key_len, int* res TSRMLS_DC) {
+    zend_rsrc_list_entry* existing_conn;
+
+    if( zend_hash_find(&EG(persistent_list), hash_key, hash_key_len+1,
+                (void**)&existing_conn) != SUCCESS )
+        return -1;
+
+    php_yrmcds_t* c = existing_conn->ptr;
+    if( (zend_bool)YRMCDS_G(detect_stale_connection) ) {
+        yrmcds_status status;
+        yrmcds_error e = check_persistent_connection(c, &status TSRMLS_CC);
+        if( e != YRMCDS_OK || status != YRMCDS_STATUS_OK ) {
+            on_broken_connection_detected(c, e, status TSRMLS_CC);
+            return -1;
+        }
+    }
+
+    *res = zend_list_insert(existing_conn->ptr, le_yrmcds TSRMLS_CC);
+    return 0;
 }
 
 // \yrmcds\Client::__construct
@@ -158,13 +220,10 @@ YRMCDS_METHOD(Client, __construct) {
     if( persist_id_len > 0 ) {
         char* hash_key;
         int hash_key_len = HASH_KEY(hash_key, persist_id);
-        zend_rsrc_list_entry* existing_conn;
 
-        if( zend_hash_find(&EG(persistent_list), hash_key, hash_key_len+1,
-                           (void**)&existing_conn) == SUCCESS ) {
-            res = zend_list_insert(existing_conn->ptr, le_yrmcds TSRMLS_CC);
-
-        } else {
+        int e = use_existing_persistent_connection(
+                    hash_key, hash_key_len, &res TSRMLS_CC);
+        if( e != 0 ) {
             php_yrmcds_t* c = pemalloc(sizeof(php_yrmcds_t), 1);
             c->persist_id = pestrndup(persist_id, persist_id_len, 1);;
             CHECK_YRMCDS( yrmcds_connect(&c->res, node, (uint16_t)port) );
@@ -1550,6 +1609,10 @@ PHP_INI_BEGIN()
     STD_PHP_INI_ENTRY("yrmcds.default_timeout",
                       "5", PHP_INI_SYSTEM, OnUpdateLong,
                       default_timeout,
+                      zend_yrmcds_globals, yrmcds_globals)
+    STD_PHP_INI_ENTRY("yrmcds.detect_stale_connection",
+                      "1", PHP_INI_SYSTEM, OnUpdateBool,
+                      detect_stale_connection,
                       zend_yrmcds_globals, yrmcds_globals)
 PHP_INI_END()
 /* }}} */

--- a/yrmcds.ini
+++ b/yrmcds.ini
@@ -10,3 +10,9 @@ yrmcds.compression_threshold = 16384
 ;
 ; Default is 5 seconds.
 yrmcds.default_timeout = 5
+
+; If detect_stale_connection is a nonzero value, the constructor of \yrmcds\Client
+; checks for stale persistent connection by emitting "noop" command to a server.
+; If the connection turns out to be stale, the constructor automatically
+; discards the connection and establishes a new persistent connection.
+yrmcds.detect_stale_connection = 1;


### PR DESCRIPTION
Currently, php-yrmcds does not check if a persistent connection is usable or not
when an application fetches an existing connection.  Broken connections are
dropped at the end of a request.

As this was an intentional design choice for maximum performance, it is handy
if we have an option to test an existing persistent connection before use.
