### PR TITLE
fix compile error on osx box

### DIFF
--- a/libyrmcds/osx.h
+++ b/libyrmcds/osx.h
@@ -1,0 +1,33 @@
+#ifndef __FINK_ENDIANDEV_PKG_ENDIAN_H__
+#define __FINK_ENDIANDEV_PKG_ENDIAN_H__ 1
+ 
+/** compatibility header for endian.h
+ * This is a simple compatibility shim to convert
+ * BSD/Linux endian macros to the Mac OS X equivalents.
+ * It is public domain.
+ * */
+ 
+#ifndef __APPLE__
+	#warning "This header file (endian.h) is MacOS X specific.\n"
+#endif	/* __APPLE__ */
+ 
+ 
+#include <libkern/OSByteOrder.h>
+ 
+#define htobe16(x) OSSwapHostToBigInt16(x)
+#define htole16(x) OSSwapHostToLittleInt16(x)
+#define be16toh(x) OSSwapBigToHostInt16(x)
+#define le16toh(x) OSSwapLittleToHostInt16(x)
+ 
+#define htobe32(x) OSSwapHostToBigInt32(x)
+#define htole32(x) OSSwapHostToLittleInt32(x)
+#define be32toh(x) OSSwapBigToHostInt32(x)
+#define le32toh(x) OSSwapLittleToHostInt32(x)
+ 
+#define htobe64(x) OSSwapHostToBigInt64(x)
+#define htole64(x) OSSwapHostToLittleInt64(x)
+#define be64toh(x) OSSwapBigToHostInt64(x)
+#define le64toh(x) OSSwapLittleToHostInt64(x)
+ 
+ 
+#endif	/* __FINK_ENDIANDEV_PKG_ENDIAN_H__ */

--- a/libyrmcds/recv.c
+++ b/libyrmcds/recv.c
@@ -3,7 +3,11 @@
 #include "yrmcds.h"
 #include "lz4/lz4.h"
 
+#ifdef __APPLE__
+#include "osx.h"
+#else
 #include <endian.h>
+#endif
 #include <errno.h>
 #include <limits.h>
 #include <stdlib.h>

--- a/libyrmcds/send.c
+++ b/libyrmcds/send.c
@@ -3,7 +3,11 @@
 #include "yrmcds.h"
 #include "lz4/lz4.h"
 
+#ifdef __APPLE__
+#include "osx.h"
+#else
 #include <endian.h>
+#endif
 #include <errno.h>
 #include <stdlib.h>
 #include <string.h>

--- a/libyrmcds/socket.c
+++ b/libyrmcds/socket.c
@@ -4,6 +4,7 @@
 
 #include <sys/socket.h>
 #include <sys/types.h>
+#include <sys/time.h>
 
 int yrmcds_fileno(yrmcds* c) {
     return c->sock;


### PR DESCRIPTION
extとあんまり関係ないんですがlibyrmcdsがosxで動作しないので動かすための簡易パッチです。

osx.hの元ネタは↓のendian.hです。
https://gist.github.com/yinyin/2027912

そのままmergeするのは考えるべき所もあると思うのでよしなにしていただければと思います。
動作確認はC++11で心が折れてしまったのでyrmcdsに対しての確認は出来ていません・・・
